### PR TITLE
typeguard 4.2.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/typing_extensions-feedstock/pr19/86c40a7

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/typing_extensions-feedstock/pr19/86c40a7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -24,8 +24,8 @@ requirements:
     - wheel
   run:
     - python
-    - importlib_metadata >=3.6   # [py<310]
-    - typing_extensions >=4.4.0  # [py<311]
+    - importlib_metadata >=3.6  # [py<310]
+    - typing_extensions >=4.10.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - importlib_metadata >=3.6  # [py<310]
-    - typing_extensions >=4.10.0
+    - typing_extensions >=4.10.0  # [py<313]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "typeguard" %}
-{% set version = "3.0.2" %}
+{% set version = "4.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fee5297fdb28f8e9efcb8142b5ee219e02375509cd77ea9d270b5af826358d5a
+  sha256: c556a1b95948230510070ca53fa0341fb0964611bd05d598d87fb52115d65fee
 
 build:
   number: 0


### PR DESCRIPTION
typeguard 4.2.1

**Destination channel:** defaults

### Links

- [PKG-4739](https://anaconda.atlassian.net/browse/PKG-4739)
- [Upstream repository](https://github.com/agronholm/typeguard/tree/4.2.1)
- [Upstream changelog/diff](https://github.com/agronholm/typeguard/releases)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/ydata-profiling-feedstock/pull/4

### Explanation of changes:

- Update version
- Update python version skip
- Update dependencies


[PKG-4739]: https://anaconda.atlassian.net/browse/PKG-4739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ