### PR TITLE
typeguard 4.5.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "4.5.2" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -25,7 +25,6 @@ requirements:
     - python
     - importlib-metadata >=3.6  # [py<310]
     - typing-extensions >=4.14.0
-    - typing_extensions >=4.14.0
 
 test:
   source_files:
@@ -45,7 +44,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v tests
+    - pytest -vv tests
 
 about:
   home: https://github.com/agronholm/typeguard

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "typeguard" %}
-{% set version = "4.5.1" %}
+{% set version = "4.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f6f8ecbbc819c9bc749983cc67c02391e16a9b43b8b27f15dc70ed7c4a007274
+  sha256: 5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423
 
 build:
   number: 0
@@ -25,6 +25,7 @@ requirements:
     - python
     - importlib-metadata >=3.6  # [py<310]
     - typing-extensions >=4.14.0
+    - typing_extensions >=4.14.0
 
 test:
   source_files:


### PR DESCRIPTION
typeguard 4.5.2 

**Destination channel:** Defaults

### Links

- [PKG-16490]
- dev_url:        https://github.com/agronholm/typeguard/tree/4.5.2
- conda_forge:    https://github.com/conda-forge/typeguard-feedstock
- pypi:           https://pypi.org/project/typeguard/4.5.2
- pypi inspector: https://inspector.pypi.io/project/typeguard/4.5.2

### Explanation of changes:

- new version number


[PKG-16490]: https://anaconda.atlassian.net/browse/PKG-16490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ